### PR TITLE
Ensuring serializer works correctly for all thread cultures

### DIFF
--- a/Json/src/JsonParser.cs
+++ b/Json/src/JsonParser.cs
@@ -163,7 +163,7 @@ namespace IPC.Reorganize.Json
 			}
 
 			var test = sb.ToString()
-						 .ToLower();
+						 .ToLowerInvariant();
 			if (test != "true" && test != "false" && test != "null")
 				throw new Exception("Invalid - expected true false or null");
 

--- a/Json/src/Naming.cs
+++ b/Json/src/Naming.cs
@@ -25,7 +25,7 @@ public static class Naming
 			for (var i = 0; i < tempParts.Length; i++)
 			{
 				tempParts[i] = tempParts[i]
-					.ToLower();
+					.ToLowerInvariant();
 			}
 			return tempParts.Where(p => !string.IsNullOrEmpty(p))
 							.ToArray();
@@ -51,7 +51,7 @@ public static class Naming
 			for (var i = 0; i < tempParts.Count; i++)
 			{
 				tempParts[i] = tempParts[i]
-					.ToLower();
+					.ToLowerInvariant();
 			}
 
 			return tempParts.Where(p => !string.IsNullOrEmpty(p))
@@ -64,8 +64,8 @@ public static class Naming
 		if (string.IsNullOrEmpty(name))
 			return name;
 
-		return ("" + name[0]).ToUpper() + name[1..]
-			.ToLower();
+		return ("" + name[0]).ToUpperInvariant() + name[1..]
+			.ToLowerInvariant();
 	}
 
 	public static string ToPascalCase(this string name)

--- a/Json/tests/NamingTests.cs
+++ b/Json/tests/NamingTests.cs
@@ -69,6 +69,16 @@ public class NamingTests
 		ClassicAssert.AreEqual("this_is_a_test", match);
 	}
 
+        [Test]
+	public void TestCultureSafety()
+	{
+	        Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.GetCultureInfo("tr-TR");
+	
+	        var test = "ThisIsATest";
+	        var match = test.ConvertName(NamingOptions.SnakeCase);
+	        ClassicAssert.AreEqual("this_is_a_test", match);
+	}
+
 	[Test]
 	public void TestNull()
 	{


### PR DESCRIPTION
Some .NET cultures have different case conversion rules. As we can't predict which environment this code will run in, we should make the serializer behave the same, regardless of the environment it runs in.

I've included a sample unit test that failed under the old code (Turkish has different rules for upper/lower casing the `I` character) but this could be made more comprehensive with examples in Danish, German, and more cultures which have different rules.